### PR TITLE
"mapDispatchToProps" takes in "dispatch" (not "state")

### DIFF
--- a/snippets/redux.cson
+++ b/snippets/redux.cson
@@ -11,7 +11,7 @@
   'mapDispatchToProps':
     'prefix': 'rdxmapdis'
     'body': """
-      function mapDispatchToProps(state) {
+      function mapDispatchToProps(dispatch) {
       	return {
       		$0
       	}


### PR DESCRIPTION
See here: https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options
